### PR TITLE
Add basic support for door_lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Read more about the [FIMP protocol](https://github.com/futurehomeno/fimp-api).
   * Accumulated energy usage (kWh) (`meter_elec`) for devices supporting this
 * Modus (home, away, sleep and vacation)
   * Set in entity `sensor.fh_mode` (read only)
+* Door locks
+  * Basic functionality (lock/unlock)
 
 
 ### Untested in new version (0.1 vs 0.2)

--- a/futurehome2mqtt/pyfimptoha/homeassistant.py
+++ b/futurehome2mqtt/pyfimptoha/homeassistant.py
@@ -3,6 +3,7 @@ import time
 import paho.mqtt.client as client
 import pyfimptoha.sensor as sensor
 import pyfimptoha.light as light
+import pyfimptoha.lock as lock
 
 
 def create_components(
@@ -78,6 +79,17 @@ def create_components(
                 )
             if status:
                 statuses.append(status)
+
+            # Door lock
+            elif service_name == "door_lock":
+                print(f"- Service: {service_name}")
+                status = lock.door_lock(
+                    device=device,
+                    mqtt=mqtt,
+                    service=service,
+                )
+                if status:
+                    statuses.append(status)
 
             # Lights
             elif functionality == "lighting":

--- a/futurehome2mqtt/pyfimptoha/lock.py
+++ b/futurehome2mqtt/pyfimptoha/lock.py
@@ -1,0 +1,48 @@
+"""
+Creates lock in Home Assistant based on FIMP services
+"""
+
+import json
+import typing
+
+
+def door_lock(
+        device: typing.Any,
+        mqtt,
+        service,
+):
+    address = device["fimp"]["address"]
+    name = device["client"]["name"]
+
+    identifier = f"fh_{address}_door_lock"
+    command_topic = f"pt:j1/mt:cmd{service['addr']}"
+    state_topic   = f"pt:j1/mt:evt{service['addr']}"
+    component = {
+        "name": f"{device['client']['name']}",
+        "object_id": identifier,
+        "unique_id": identifier,
+        "command_topic": command_topic,
+        "state_topic": state_topic,
+        "payload_lock": '{"props":{},"serv":"door_lock","tags":[],"type":"cmd.lock.set","val":true,"val_t":"bool"}',
+        "payload_unlock": '{"props":{},"serv":"door_lock","tags":[],"type":"cmd.lock.set","val":false,"val_t":"bool"}',
+        "value_template": '{{ iif(value_json.val["is_secured"], "LOCKED", "UNLOCKED", None) }}',
+    }
+    payload = json.dumps(component)
+    mqtt.publish(f"homeassistant/lock/{identifier}/config", payload)
+
+    # Queue statuses
+    status = None
+    if device.get("param") and device['param'].get('lockState'):
+        lockState = device['param']['lockState']
+        data = {
+            "props": {},
+            "serv": "door_lock",
+            "type": "evt.lock.report",
+            "val_t": "bool_map",
+            "val": {
+                "is_secured": True if lockState == 'locked' else False,
+            }
+        }
+        payload = json.dumps(data)
+        status = (state_topic, payload)
+    return status


### PR DESCRIPTION
Adds support for the FIMP service 'door_lock' as a Lock component in Home Assistant. It supports read/write of the mandatory states LOCKED and UNLOCKED.

Tested with ID Lock 150.