### PR TITLE
Fix unit_of_measurement of illuminance

### DIFF
--- a/futurehome2mqtt/pyfimptoha/sensor.py
+++ b/futurehome2mqtt/pyfimptoha/sensor.py
@@ -60,7 +60,7 @@ def sensor_lumin(
 
     identifier = f"fh_{address}_illuminance"
     state_topic = f"pt:j1/mt:evt{service['addr']}"
-    unit_of_measurement = "Lux"
+    unit_of_measurement = "lx"
     component = {
         "name": f"{name} (belysningsstyrke)",
         "object_id": identifier,


### PR DESCRIPTION
I noticed this warning in my logs:
> Entity sensor.fh_17_illuminance (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) is using native unit of measurement 'Lux' which is not a valid unit for the device class ('illuminance') it is using; expected one of ['lx']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22

Not sure if it has any practical implications other than silencing the warning, but I guess it's worth fixing anyway 🙂 